### PR TITLE
Pick only first album when building embed message

### DIFF
--- a/YMDB/Bot/Extensions/YTrackExtensions.cs
+++ b/YMDB/Bot/Extensions/YTrackExtensions.cs
@@ -18,7 +18,7 @@ namespace YMDB.Bot.Extensions
                 .WithImageUrl($"http://{track.CoverUri.Replace("%%", "1000x1000")}")
                 .WithColor(DiscordColor.Aquamarine)
                 .AddField("Artists", $"{track.Artists.toString()}", true)
-                .AddField("Album", $"{track.Albums.toString()}", true)
+                .AddField("Album", $"{track.Albums.First().Title}", true)
                 .AddField("Duration", $"{track.GetDuration().ToString()}", true);
         }
 


### PR DESCRIPTION
Пытался добавить в очередь безумно популярную песню (например, https://music.yandex.ru/album/7190880/track/51516485), бот выкинул **прямо в чат** вот такое: `System.ArgumentException: Embed field value length cannot exceed 1024 characters`, после чего отказался включать песенку :(

Оказалось, что API у Я.Музыки закидывает в "альбомы" вообще все сборники, в которых когда-либо что-либо было занесено. Ну а там их штук 150, дискорд попросил такое больше ему на распечатку не присылать.

Мы же немногое потеряем, если в сообщении в чатик будет только самый первый альбом? Смотрите изменения, в общем.